### PR TITLE
fix(test): only init tracing once

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload coverage report
         if: steps.cargo-testcov.outcome == 'success'
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./lcov.info


### PR DESCRIPTION
This commit will enable the run of the tests in inside the testing folder without raising the following error:

> Unable to install global subscriber: SetGlobalDefaultError("a global default trace dispatcher has already been set")
