### PR TITLE
doc: Fix download URLs in READMEs install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ Nightly binaries are also available for major platforms, please check [Releases]
 
 ```bash
 # One-line
-curl -L https://github.com/Desdaemon/odoo-lsp/releases/download/latest/odoo-lsp-x86_64-unknown-linux-musl.tgz | tar -xzvf -
+curl -L https://github.com/Desdaemon/odoo-lsp/releases/latest/download/odoo-lsp-x86_64-unknown-linux-musl.tgz | tar -xzvf -
 
 # Apple Silicon
-curl -L https://github.com/Desdaemon/odoo-lsp/releases/download/latest/odoo-lsp-aarch64-apple-darwin.tgz | tar -xzvf -
+curl -L https://github.com/Desdaemon/odoo-lsp/releases/latest/download/odoo-lsp-aarch64-apple-darwin.tgz | tar -xzvf -
 
 # With cargo-binstall
 cargo binstall odoo-lsp


### PR DESCRIPTION
The URL for assets is usually of the form `github.com/<USER>/<REPO>/releases/download/<VERSION_TAG>/<ASSET_NAME>`.
However, when linking to the latest release, the "latest" comes before the "download" part instead of just replacing the version tag.